### PR TITLE
Use master database in sp_add_jobstep call

### DIFF
--- a/src/JobRunner/JobRunner/Stored Procedures/AddAgentJob.sql
+++ b/src/JobRunner/JobRunner/Stored Procedures/AddAgentJob.sql
@@ -1,4 +1,4 @@
-﻿create procedure JobRunner.AddAgentJob
+create procedure JobRunner.AddAgentJob
 	@JobRunnerName sysname,
 	@CategoryName sysname,
 	@ServerName sysname,
@@ -25,6 +25,7 @@ declare
 	@Msg nvarchar(200);
 
 declare	@Command nvarchar(2000) =
+    N'use ' + @DatabaseName + N'; ' +
 	N'if exists ' +
 	N'(select 1 from sys.procedures where ' +
 	N'object_schema_name(object_id) = N''JobRunner'' ' +
@@ -110,7 +111,7 @@ begin try
 				@os_run_priority = 0,
 				@subsystem = N'TSQL',
 				@command = @Command,
-				@database_name = @DatabaseName,
+				@database_name = N'master',
 				@flags = 0;
 
 			if @@error != 0 or @ReturnCode != 0 throw 50000, N'Could not create job step', 1;


### PR DESCRIPTION
Dave Dustin's issue - #7 - identified an issue with the use of `sp_add_jobstep` on a non-master database.

This change resolves that by:
- Specifying `master` for the `@database_name` parameter
- Using a `use <database_name>` statement in the SQL query that is the job step.

Thanks to Dave for pointing this one out.